### PR TITLE
error message correction

### DIFF
--- a/app/service/user_service.py
+++ b/app/service/user_service.py
@@ -9,7 +9,7 @@ user_model = User()
 def create_user(data):
     try:
         if user_model.get_by_email(data['email']):
-            return {"error": "User with this email already exists."}, 400
+            return {"error":"User with this email already exists."}
         
         password_hash = generate_password_hash(data['password'])
         status = data.get('status', 'Active')

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -289,9 +289,9 @@ def test_create_user_duplicate_email(client):
                            headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 400
     data = response.get_json()
-    assert isinstance(data, list)
-    assert "error" in data[0]
-    assert data[0]["error"] == "User with this email already exists."
+    assert isinstance(data, dict)
+    assert "error" in data
+    assert data["error"] == "User with this email already exists."
 
 
 def test_access_protected_endpoint_without_token(client):


### PR DESCRIPTION
## Summary by Sourcery

Standardize duplicate-email error response to return a single JSON object and update tests to match the new response format

Bug Fixes:
- Return only an error JSON object (not a tuple) from create_user on duplicate email
- Adjust unit tests to expect a dict with an "error" key instead of a list containing one