### PR TITLE
Seed default admin

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -53,5 +53,9 @@ def create_app(testing=False):
         # Enable CORS
     CORS(app, resources={r"/*": {"origins": "*"}})  # Allow all origins — change this to specific origin if needed
 
+    # Insert dummy admin user and profile
+    with app.app_context():
+        from app.utils.seed import insert_dummy_admin
+        insert_dummy_admin()
 
     return app

--- a/app/models/employee_profile.py
+++ b/app/models/employee_profile.py
@@ -58,7 +58,7 @@ class EmployeeProfile(Database):
 
     def get_by_employee_id(self, employee_id):
         cursor = self.conn.execute('''
-            SELECT ep.*, u.employee_id FROM employee_profiles ep
+            SELECT ep.*, u.employee_id, u.name, u.email FROM employee_profiles ep
             JOIN users u ON ep.user_id = u.employee_id
             WHERE u.employee_id = ?
         ''', (employee_id,))

--- a/app/utils/seed.py
+++ b/app/utils/seed.py
@@ -1,0 +1,49 @@
+# app/seed.py
+
+from app.models.user import User
+from app.models.employee_profile import EmployeeProfile
+from werkzeug.security import generate_password_hash
+
+def insert_dummy_admin():
+    user_model = User()
+    profile_model = EmployeeProfile()
+
+    existing = user_model.get_by_email("admin@example.com")
+    if existing:
+        print("ℹ️ Dummy admin user already exists.")
+        return
+
+    user_model.add(
+        name="Test Admin",
+        email="admin@example.com",
+        phone="9999999999",
+        department="HR",
+        role="Admin",
+        password_hash=generate_password_hash("admin")
+    )
+
+    profile_data = {
+        "personal_details": {
+            "first_name": "Jane",
+            "middle_name": "K",
+            "last_name": "Doe",
+            "dob": "1992-05-10",
+            "gender": "Female"
+        },
+        "contact_details": {
+            "email": "admin@example.com",
+            "phone": "2223334444",
+            "address": "456 Main Street"
+        },
+        "emergency_contacts": [],
+        "dependents": [],
+        "job_details": {},
+        "salary_details": {},
+        "report_to": {},
+        "qualifications": []
+    }
+
+    user = user_model.get_by_email("admin@example.com")
+    profile_model.create_profile(user['employee_id'], profile_data)
+
+    print("✅ Dummy admin user created successfully.")

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -289,9 +289,9 @@ def test_create_user_duplicate_email(client):
                            headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 400
     data = response.get_json()
-    assert isinstance(data, list)
-    assert "error" in data[0]
-    assert data[0]["error"] == "User with this email already exists."
+    assert isinstance(data, dict)
+    assert 'error' in data
+    assert data['error'] == "User with this email already exists."
 
 
 def test_access_protected_endpoint_without_token(client):


### PR DESCRIPTION
## Summary by Sourcery

Seed a default admin user at application startup via a new seeding utility, enrich the employee profile query to include user name and email, and update tests to expect the revised error response format.

New Features:
- Seed a default admin user on application initialization.
- Introduce an insert_dummy_admin utility to create the default admin if missing.

Enhancements:
- Extend get_by_employee_id to return the user’s name and email.
- Update SQL query in EmployeeProfile to include user details.

Tests:
- Revise duplicate email test to assert the error response as a dict instead of a list.